### PR TITLE
Button to close tabs stashed in specific folder

### DIFF
--- a/src/model/index.test.ts
+++ b/src/model/index.test.ts
@@ -272,6 +272,18 @@ describe('model', () => {
             });
         });
 
+        it('from a specified list',  async () => {
+            expect(model.options.local.state.after_stashing_tab, "This test expects tabs to be hidden.")
+                .to.equal('hide');
+            const bms = await browser.bookmarks.getChildren(bookmarks.names.id);
+            const urls = filterMap(bms, i => i.url)
+            await model.closeTabs(urls)
+            await events.next(browser.tabs.onUpdated)
+            const win = await browser.tabs.query({windowId: windows.real.id, pinned: false})
+            expect(win.reduce((b, t) => b || (!t.hidden && t.url !== undefined && urls.includes(t.url)), false))
+                .to.equal(false)
+        });
+
         it('opens a new empty tab if needed to keep the window open', async () => {
             await model.options.local.set({after_stashing_tab: 'hide'});
             await events.next(browser.storage.onChanged);

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -350,11 +350,11 @@ export class Model {
     ) {
         const toWindowId = this.tabs.targetWindow.value;
         if (toWindowId === undefined) {
-            throw new Error(`No target window; not sure where to restore tabs`);
+            throw new Error(`No target window; don't want to unexpectedly close tabs`);
         }
         const cur_win = expect(this.tabs.window(toWindowId),
             () => `Target window ${toWindowId} is unknown to the model`);
-        // Remove duplicate URLs so we only try to restore each URL once.
+        // Remove duplicate URLs so we only try to close each URL once.
         const url_set = new Set(filterMap(urls, url => url));
         // Only consider the tabs in the current window
         const win_tabs = this.tabs.tabsIn(cur_win);

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -342,6 +342,27 @@ export class Model {
         }
     }
 
+    /** Closes all the stashed tabs with the specified urls.
+     *
+     */
+    async closeTabs(
+        urls: string[]
+    ) {
+        const toWindowId = this.tabs.targetWindow.value;
+        if (toWindowId === undefined) {
+            throw new Error(`No target window; not sure where to restore tabs`);
+        }
+        const cur_win = expect(this.tabs.window(toWindowId),
+            () => `Target window ${toWindowId} is unknown to the model`);
+        // Remove duplicate URLs so we only try to restore each URL once.
+        const url_set = new Set(filterMap(urls, url => url));
+        // Only consider the tabs in the current window
+        const win_tabs = this.tabs.tabsIn(cur_win);
+        await this.hideOrCloseStashedTabs(win_tabs
+            .filter(t => t && ! t.hidden && ! t.pinned && url_set.has(t.url))
+            .map(t => t.id));
+    }
+
     /** Restores the specified URLs as new tabs in the current window.  Returns
      * the IDs of the restored tabs.
      *

--- a/src/stash-list/folder.vue
+++ b/src/stash-list/folder.vue
@@ -18,6 +18,8 @@
               :tooltip="`Open all tabs in the group and delete the group `
                       + `(hold ${bgKey} to open in background)`" />
       <Button class="remove" @action="remove" tooltip="Delete this group" />
+      <Button class="remove stashed" @action="closeGroup"
+              :tooltip="`Close all tabs in this group`" />
     </ButtonBox>
     <ButtonBox v-else class="folder-actions">
         <Button class="stash here" @action="move"
@@ -165,6 +167,10 @@ export default defineComponent({
                 toFolderId: this.folder.id,
             }));
         },
+
+        async closeGroup() {this.attempt(async() =>{
+            await this.model().closeTabs(this.validChildren.map(b => b.url))
+        })},
 
         async stashOne(ev: MouseEvent | KeyboardEvent) {this.attempt(async() => {
             const tab = this.model().tabs.activeTab();


### PR DESCRIPTION
This pull request adds a button to each folder which closes all open tabs that are stashed in that folder. 

I've found myself wanting to intermittently open a folder, like my podcast/media or weather folder, and then close it again without closing all the other stashed tabs, so I added a button corresponding to the "Close all stashed tabs" button at the top, but for each specific group. 
It might make sense to change the color of this button and its position in the row, I'll leave that up to your design judgement ;)