### PR TITLE
add newtab override

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -27,6 +27,9 @@
     ],
     "content_security_policy":
         "script-src 'self'; object-src 'self';",
+    "chrome_url_overrides" : {
+        "newtab": "stash-list.html"
+    },
     "background": {
         "scripts": ["lib.js", "index.js"]
     },

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -28,7 +28,7 @@
     "content_security_policy":
         "script-src 'self'; object-src 'self';",
     "chrome_url_overrides" : {
-        "newtab": "stash-list.html"
+        "newtab": "new-tab.html"
     },
     "background": {
         "scripts": ["lib.js", "index.js"]

--- a/assets/new-tab.html
+++ b/assets/new-tab.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Tab Stash</title>
+    <link rel="icon" href="../icons/logo.svg">
+    <!-- XXX This doesn't work yet:
+    <link rel="icon" media="inverted-colors: inverted" href="../icons/logo-light.svg">
+    -->
+    <link rel="stylesheet" type="text/css" href="tab-stash.css">
+    <script type="text/javascript" src="lib.js"></script>
+    <script type="text/javascript" src="stash-list.js"></script>
+</head>
+
+<body>
+</body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
         "deleted-items": "./src/deleted-items/index.ts",
         "restore": "./src/restore/index.ts",
         "stash-list": "./src/stash-list/index.ts",
+        "new-tab": "./src/stash-list/index.ts",
         "options": "./src/options/index.ts",
         "whats-new": "./src/whats-new/index.ts",
     },


### PR DESCRIPTION
Changes the manifest.json so that the extension changes the new tab page. The user can use a drop down in the settings to go back to the default new tab page. Addresses #93 