### PR TITLE
feat: Allow middle click to close open tabs.

### DIFF
--- a/src/stash-list/bookmark.vue
+++ b/src/stash-list/bookmark.vue
@@ -112,6 +112,7 @@ export default defineComponent({
 
             // If bookmark has no open tabs, open a new one in the background.
             if (openTabs.length < 1) {
+                if (! this.bookmark.url) return;
                 return await this.model().restoreTabs(
                     [this.bookmark.url], { background: true });
             }

--- a/src/stash-list/bookmark.vue
+++ b/src/stash-list/bookmark.vue
@@ -13,7 +13,8 @@
                               'icon-tab-selected-inverse': bookmark.$selected}"
              @click.prevent.stop="select" />
   <a class="text" :href="bookmark.url" target="_blank" draggable="false" ref="a"
-     @click.prevent.stop="open">{{bookmark.title}}</a>
+     @click.left.prevent.stop="open"
+     @auxclick.middle.exact.prevent.stop="closeTabs">{{bookmark.title}}</a>
   <ButtonBox>
     <Button class="restore-remove" @action="openRemove"
             :tooltip="`Open this tab and delete it from the group `
@@ -100,6 +101,12 @@ export default defineComponent({
 
         remove() { this.model().attempt(async () => {
             await this.model().deleteBookmark(this.bookmark);
+        })},
+
+        closeTabs(ev: MouseEvent) { this.model().attempt(async () => {
+            await this.model().tabs.remove(this.related_tabs
+                .filter((t) => ! t.hidden && t.windowId === this.targetWindow)
+                .map((t) => t.id))
         })},
 
         openRemove(ev: MouseEvent) { this.model().attempt(async () => {

--- a/src/stash-list/tab.vue
+++ b/src/stash-list/tab.vue
@@ -12,7 +12,8 @@
                               'icon-tab-selected-inverse': tab.$selected}"
              @click.prevent.stop="select" />
   <a class="text" :href="tab.url" target="_blank" draggable="false" ref="a"
-     @click.prevent.stop="open">{{tab.title}}</a>
+     @click.left.prevent.stop="open"
+     @auxclick.middle.exact.prevent.stop="remove">{{tab.title}}</a>
   <ButtonBox>
     <Button class="stash one" @action="stash"
             :tooltip="`Stash this tab (hold ${altKey} to keep tab open)`" />


### PR DESCRIPTION
1. Middle click on an open tab (in `Unstashed Tabs` or `Open Tabs` if the `Show All Open Tabs` is enabled) will close it.
2. Middle click on a bookmark with open related tabs will close them.

The binding for middle click is exact, so using any modifiers like `SHIFT` will use the default behavior for links. So it's still possible to do stuff like open multiple copies of a tab/bookmark even when there are open tabs.

*Note*: One minor cosmetic issue I noticed is that when middle clicking bookmarks that don't have any open tabs, the hover highlight seems to get stuck. I wasn't able to figure out why this occurs, but clicking anywhere clears the redundant highlight and there's only ever one at a time.

Closes #215