### PR TITLE
feat: Support showing color coded container indicators

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -23,7 +23,9 @@
         "contextMenus",
         "browserSettings",
         "storage",
-        "unlimitedStorage"
+        "unlimitedStorage",
+        "contextualIdentities",
+        "cookies"
     ],
     "content_security_policy":
         "script-src 'self'; object-src 'self';",

--- a/src/mock/browser/containers.ts
+++ b/src/mock/browser/containers.ts
@@ -1,0 +1,56 @@
+import type {ContextualIdentities as CI} from 'webextension-polyfill';
+
+import * as events from '../events';
+
+class MockContainers implements CI.Static {
+    readonly onCreated: events.MockEvent<(createInfo: CI.OnCreatedChangeInfoType) => void> =
+        new events.MockEvent('browser.contextualIdentities.onCreated');
+    readonly onRemoved: events.MockEvent<(removeInfo: CI.OnRemovedChangeInfoType) => void> =
+        new events.MockEvent('browser.contextualIdentities.onRemoved');
+    readonly onUpdated: events.MockEvent<(changeInfo: CI.OnUpdatedChangeInfoType) => void> =
+        new events.MockEvent('browser.contextualIdentities.onUpdated');
+
+    constructor() {
+        return;
+    }
+
+    // istanbul ignore next
+    async get(cookieStoreId: string): Promise<CI.ContextualIdentity> {
+        throw new Error('Method not implemented.');
+    }
+
+    // istanbul ignore next
+    async query(details: CI.QueryDetailsType): Promise<CI.ContextualIdentity[]> {
+        throw new Error('Method not implemented.');
+    }
+
+    // istanbul ignore next
+    async create(details: CI.CreateDetailsType): Promise<CI.ContextualIdentity> {
+        throw new Error('Method not implemented.');
+    }
+
+    // istanbul ignore next
+    async update(cookieStoreId: string, details: CI.UpdateDetailsType): Promise<CI.ContextualIdentity> {
+        throw new Error('Method not implemented.');
+    }
+
+    // istanbul ignore next
+    async remove(cookieStoreId: string): Promise<CI.ContextualIdentity> {
+        throw new Error('Method not implemented.');
+    }
+}
+
+export default (() => {
+    const exports = {
+        contextualIdentities: new MockContainers(),
+
+        reset() {
+            exports.contextualIdentities = new MockContainers();
+            (<any>globalThis).browser.contextualIdentities = exports.contextualIdentities;
+        }
+    };
+
+    exports.reset();
+
+    return exports;
+})();

--- a/src/mock/browser/index.ts
+++ b/src/mock/browser/index.ts
@@ -2,5 +2,6 @@ import storage from './storage';
 import runtime from './runtime';
 import bookmarks from './bookmarks';
 import tabs_and_windows from './tabs-and-windows';
+import containers from './containers';
 
-export {storage, runtime, bookmarks, tabs_and_windows};
+export {storage, runtime, bookmarks, tabs_and_windows, containers};

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -30,6 +30,7 @@ export const mochaHooks: RootHookObject = {
         mock_browser.storage.reset();
         mock_browser.bookmarks.reset();
         mock_browser.tabs_and_windows.reset();
+        mock_browser.containers.reset();
     },
     async afterEach() {
         await events.afterTest();

--- a/src/model/containers.ts
+++ b/src/model/containers.ts
@@ -91,8 +91,7 @@ export class Model {
 
     // Accessors
     container(key: string): Container | undefined {
-        // Something like a blank string should never be valid.
-        return key ? this.containers.get(key) : undefined;
+        return this.containers.get(key);
     }
 
     // Event handlers
@@ -101,12 +100,10 @@ export class Model {
         ContextualIdentities.OnUpdatedChangeInfoType) {
 
         const container = evt.contextualIdentity;
-        const key = container?.cookieStoreId;
-        if (!key) return;
-        let c = this.containers.get(key) as Container;
+        const key = container.cookieStoreId;
+        let c = this.containers.get(key);
         if (!c) {
-            c = this.makeContainerReactive(c);
-            this.containers.set(key, c);
+            this.containers.set(key, this.makeContainerReactive(container));
             return;
         }
         c.name = container.name;
@@ -118,8 +115,7 @@ export class Model {
     }
 
     private whenRemoved(evt: ContextualIdentities.OnRemovedChangeInfoType) {
-        const key = evt.contextualIdentity?.cookieStoreId;
-        if (!key) return;
+        const key = evt.contextualIdentity.cookieStoreId;
         this.containers.delete(key);
     }
 }

--- a/src/model/containers.ts
+++ b/src/model/containers.ts
@@ -1,0 +1,125 @@
+import {reactive} from "vue";
+import {contextualIdentities, ContextualIdentities} from 'webextension-polyfill';
+import {backingOff} from "../util";
+import {logErrorsFrom} from "../util/oops";
+import {EventWiring} from "../util/wiring";
+
+export type Container = ContextualIdentities.ContextualIdentity;
+
+type ContainerMap = Map<string, Container>;
+
+export class Model {
+    private containers: ContainerMap = new Map;
+    enabled: boolean;
+
+    // Did we receive an event since the last (re)load of the model?
+    private _event_since_load: boolean = false;
+
+    constructor() {
+        const supports_containers = [
+            typeof contextualIdentities?.query,
+            typeof contextualIdentities?.onCreated?.addListener,
+            typeof contextualIdentities?.onUpdated?.addListener,
+            typeof contextualIdentities?.onRemoved?.addListener]
+            .every(v => v === 'function');
+        if (!supports_containers) {
+            // Avoid blowing up if running on a browser with no container support.
+            this.enabled = false;
+            return;
+        }
+
+        this.enabled = true;
+        const wiring = new EventWiring(this, {
+            onFired: () => {this._event_since_load = true;},
+            // istanbul ignore next -- safety net; reload the model in the event
+            // of an unexpected exception.
+            onError: () => {logErrorsFrom(() => this.reload());},
+        });
+
+        wiring.listen(contextualIdentities.onCreated, this.whenChanged);
+        wiring.listen(contextualIdentities.onUpdated, this.whenChanged);
+        wiring.listen(contextualIdentities.onRemoved, this.whenRemoved);
+    }
+
+    static async from_browser(): Promise<Model> {
+        const model = new Model();
+        await model.reload();
+        return model;
+    }
+
+    // Fetch containers from the browser again and update the model's
+    // understanding of the world with the browser's data.  Use this if it looks
+    // like the model has gotten out of sync with the browser (e.g. for crash
+    // recovery).
+    readonly reload = backingOff(async () => {
+        if (!this.enabled) return;
+        // We loop until we can complete a reload without receiving any
+        // concurrent events from the browser--if we get a concurrent event, we
+        // need to try loading again, since we don't know how the event was
+        // ordered with respect to the query().
+        let loaded_containers: Container[];
+
+        this._event_since_load = true;
+        while (this._event_since_load) {
+            this._event_since_load = false;
+            try {
+                loaded_containers = await contextualIdentities.query({});
+            } catch (e) {
+                // Containers can be manually disabled in Firefox by setting
+                // privacy.userContext.enabled to false. When this is the case,
+                // calling .query() will raise an exception.
+                this.enabled = false;
+                loaded_containers = [];
+                break;
+            }
+        }
+        this.containers = new Map(loaded_containers!
+            .filter(c => c?.cookieStoreId)
+            .map(c => [c.cookieStoreId, this.makeContainerReactive(c)]));
+    });
+
+    private makeContainerReactive(c: Container): Container {
+        return reactive({
+            name: c.name,
+            icon: c.icon,
+            iconUrl: c.iconUrl,
+            color: c.color,
+            colorCode: c.colorCode,
+            cookieStoreId: c.cookieStoreId
+        });
+    }
+
+    // Accessors
+    container(key: string): Container | undefined {
+        // Something like a blank string should never be valid.
+        return key ? this.containers.get(key) : undefined;
+    }
+
+    // Event handlers
+    private whenChanged(evt:
+        ContextualIdentities.OnCreatedChangeInfoType |
+        ContextualIdentities.OnUpdatedChangeInfoType) {
+
+        const container = evt.contextualIdentity;
+        const key = container?.cookieStoreId;
+        if (!key) return;
+        let c = this.containers.get(key) as Container;
+        if (!c) {
+            c = this.makeContainerReactive(c);
+            this.containers.set(key, c);
+            return;
+        }
+        c.name = container.name;
+        c.icon = container.icon;
+        c.iconUrl = container.iconUrl;
+        c.color = container.color;
+        c.colorCode = container.colorCode;
+        c.cookieStoreId = container.cookieStoreId;
+    }
+
+    private whenRemoved(evt: ContextualIdentities.OnRemovedChangeInfoType) {
+        const key = evt.contextualIdentity?.cookieStoreId;
+        if (!key) return;
+        this.containers.delete(key);
+    }
+}

--- a/src/model/index.test.ts
+++ b/src/model/index.test.ts
@@ -62,6 +62,7 @@ describe('model', () => {
                 local: await stored_object_factory.get('local', 'test_options', LOCAL_DEF),
             }),
             tabs: tab_model,
+            containers: await M.Containers.Model.from_browser(),
             bookmarks: bm_model,
             deleted_items: new M.DeletedItems.Model(deleted_items),
             favicons: new M.Favicons.Model(new KVSCache(favicons)),

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -42,6 +42,7 @@ import * as BrowserSettings from './browser-settings';
 import * as Options from './options';
 
 import * as Tabs from './tabs';
+import * as Containers from './containers';
 import * as Bookmarks from './bookmarks';
 import * as DeletedItems from './deleted-items';
 
@@ -51,7 +52,7 @@ import * as Selection from './selection';
 
 export {
     BrowserSettings, Options, Tabs, Bookmarks, DeletedItems, Favicons,
-    BookmarkMetadata,
+    BookmarkMetadata, Containers,
 };
 
 /** The StashItem is anything that can be placed in the stash.  It could already
@@ -83,6 +84,7 @@ export type Source = {
     readonly options: Options.Model,
 
     readonly tabs: Tabs.Model;
+    readonly containers: Containers.Model;
     readonly bookmarks: Bookmarks.Model;
     readonly deleted_items: DeletedItems.Model,
 
@@ -103,6 +105,7 @@ export class Model {
     readonly options: Options.Model;
 
     readonly tabs: Tabs.Model;
+    readonly containers: Containers.Model;
     readonly bookmarks: Bookmarks.Model;
     readonly deleted_items: DeletedItems.Model;
 
@@ -115,6 +118,7 @@ export class Model {
         this.options = src.options;
 
         this.tabs = src.tabs;
+        this.containers = src.containers;
         this.bookmarks = src.bookmarks;
         this.deleted_items = src.deleted_items;
 
@@ -128,6 +132,7 @@ export class Model {
     readonly reload = backingOff(async () => {
         await Promise.all([
             this.tabs.reload(),
+            this.containers.reload(),
             this.bookmarks.reload(),
             this.browser_settings.reload(),
         ]);

--- a/src/model/options.ts
+++ b/src/model/options.ts
@@ -112,6 +112,9 @@ export const LOCAL_DEF = {
     /** Re-open a recently-closed tab if one can't be found.  Disabled by
      * default because of bugs in Firefox.  See #188. */
     ff_restore_closed_tabs: {default: false, is: aBoolean},
+
+    /** Container color indicators. Related issue: #125 */
+    ff_container_indicators: {default: false, is: aBoolean},
 } as const;
 
 export type Source = {

--- a/src/model/tabs.test.ts
+++ b/src/model/tabs.test.ts
@@ -36,6 +36,7 @@ describe('model/tabs', () => {
                 active: !!tab.active,
                 highlighted: !!tab.highlighted,
                 discarded: !!tab.discarded,
+                cookieStoreId: tab.cookieStoreId ?? '',
                 $visible: true,
                 $selected: false,
             });
@@ -68,6 +69,7 @@ describe('model/tabs', () => {
             pinned: false,
             highlighted: false,
             discarded: false,
+            cookieStoreId: '',
             $visible: true,
             $selected: false,
         });
@@ -148,6 +150,7 @@ describe('model/tabs', () => {
         const tab = {
             id: 16384, windowId: 16590, index: 0, url: 'hi',
             highlighted: false, active: false, pinned: false, incognito: false,
+            cookieStoreId: undefined,
         };
         events.send(browser.tabs.onCreated, tab);
         await events.next(browser.tabs.onCreated);
@@ -164,6 +167,7 @@ describe('model/tabs', () => {
             active: false,
             highlighted: false,
             discarded: false,
+            cookieStoreId: tab.cookieStoreId ?? '',
             $visible: true,
             $selected: false,
         });
@@ -207,6 +211,7 @@ describe('model/tabs', () => {
             active: !!tab.active,
             highlighted: !!tab.highlighted,
             discarded: !!tab.discarded,
+            cookieStoreId: tab.cookieStoreId ?? '',
             $visible: true,
             $selected: false,
         });

--- a/src/model/tabs.test.ts
+++ b/src/model/tabs.test.ts
@@ -36,7 +36,7 @@ describe('model/tabs', () => {
                 active: !!tab.active,
                 highlighted: !!tab.highlighted,
                 discarded: !!tab.discarded,
-                cookieStoreId: tab.cookieStoreId ?? '',
+                cookieStoreId: tab.cookieStoreId,
                 $visible: true,
                 $selected: false,
             });
@@ -69,7 +69,7 @@ describe('model/tabs', () => {
             pinned: false,
             highlighted: false,
             discarded: false,
-            cookieStoreId: '',
+            cookieStoreId: undefined,
             $visible: true,
             $selected: false,
         });
@@ -167,7 +167,7 @@ describe('model/tabs', () => {
             active: false,
             highlighted: false,
             discarded: false,
-            cookieStoreId: tab.cookieStoreId ?? '',
+            cookieStoreId: tab.cookieStoreId,
             $visible: true,
             $selected: false,
         });
@@ -211,7 +211,7 @@ describe('model/tabs', () => {
             active: !!tab.active,
             highlighted: !!tab.highlighted,
             discarded: !!tab.discarded,
-            cookieStoreId: tab.cookieStoreId ?? '',
+            cookieStoreId: tab.cookieStoreId,
             $visible: true,
             $selected: false,
         });

--- a/src/model/tabs.ts
+++ b/src/model/tabs.ts
@@ -15,6 +15,7 @@ export type Tab = {
     title: string,
     url: string,
     favIconUrl: string,
+    cookieStoreId: string,
     pinned: boolean,
     hidden: boolean,
     active: boolean,
@@ -345,6 +346,7 @@ export class Model {
                 title: tab.title ?? '',
                 url: tab.url ?? '',
                 favIconUrl: tab.favIconUrl ?? '',
+                cookieStoreId: tab.cookieStoreId ?? '',
                 pinned: tab.pinned,
                 hidden: tab.hidden ?? false,
                 active: tab.active,
@@ -368,6 +370,7 @@ export class Model {
             t.title = tab.title ?? '';
             t.url = tab.url ?? '';
             t.favIconUrl = tab.favIconUrl ?? '';
+            t.cookieStoreId = tab.cookieStoreId ?? '';
             t.pinned = tab.pinned;
             t.hidden = tab.hidden ?? false;
             t.active = tab.active;

--- a/src/model/tabs.ts
+++ b/src/model/tabs.ts
@@ -15,7 +15,7 @@ export type Tab = {
     title: string,
     url: string,
     favIconUrl: string,
-    cookieStoreId: string,
+    cookieStoreId: string | undefined,
     pinned: boolean,
     hidden: boolean,
     active: boolean,
@@ -346,7 +346,7 @@ export class Model {
                 title: tab.title ?? '',
                 url: tab.url ?? '',
                 favIconUrl: tab.favIconUrl ?? '',
-                cookieStoreId: tab.cookieStoreId ?? '',
+                cookieStoreId: tab.cookieStoreId,
                 pinned: tab.pinned,
                 hidden: tab.hidden ?? false,
                 active: tab.active,
@@ -370,7 +370,7 @@ export class Model {
             t.title = tab.title ?? '';
             t.url = tab.url ?? '';
             t.favIconUrl = tab.favIconUrl ?? '';
-            t.cookieStoreId = tab.cookieStoreId ?? '';
+            t.cookieStoreId = tab.cookieStoreId;
             t.pinned = tab.pinned;
             t.hidden = tab.hidden ?? false;
             t.active = tab.active;

--- a/src/options/index.vue
+++ b/src/options/index.vue
@@ -227,6 +227,15 @@
       occasionally restore incorrect tabs on certain versions of Firefox, check
       the linked issue for more details.)
     </FeatureFlag>
+
+    <FeatureFlag name="ff_container_indicators" v-model="ff_container_indicators"
+        :default_value="local_def().ff_container_indicators.default" :issue="125">
+      <template v-slot:summary>Container Indicators</template>
+      Displays color-coded indicators for container tabs and bookmarks
+      with open container tabs. <b>Note:</b> Tab Stash itself does not manage
+      containers or ensure that bookmarks are opened in a specific container.
+      This feature only shows what container a tab belongs to.
+    </FeatureFlag>
   </section>
 </main>
 </template>

--- a/src/service-model.ts
+++ b/src/service-model.ts
@@ -24,6 +24,7 @@ export default async function(): Promise<M.Model> {
         browser_settings: M.BrowserSettings.Model.live(),
         options: M.Options.Model.live(),
         tabs: M.Tabs.Model.from_browser('background'),
+        containers: M.Containers.Model.from_browser(),
         bookmarks: M.Bookmarks.Model.from_browser(),
         deleted_items: new M.DeletedItems.Model(kvs.deleted_items),
     });

--- a/src/stash-list/bookmark.vue
+++ b/src/stash-list/bookmark.vue
@@ -7,6 +7,7 @@
               'discarded': discarded,
               'selected': bookmark.$selected}"
      :title="bookmark.title" :data-id="bookmark.id"
+     :data-container-color="related_container_color"
      @click.prevent.stop="select">
   <item-icon class="action select"
              :src="! bookmark.$selected ? favicon?.value?.favIconUrl : ''"
@@ -68,6 +69,27 @@ export default defineComponent({
         discarded(): boolean {
             return this.related_tabs.length > 0 && 
                 this.related_tabs.every(t => !t.hidden && t.discarded);
+        },
+
+        related_container_color(): string | undefined {
+            if (!this.model().options.local.state.ff_container_indicators) return;
+            const containers = this.model().containers;
+
+            // Reduce here has three states:
+            //   undefined: We'll set the state if the tab isn't hidden and there's
+            //     a container color associated with this tab.
+            //   null: We had a container color in the state, but then we saw
+            //     a different one.
+            //   string: One or more tabs with a container color, and all
+            //     set to the same color.
+            const container_color = this.related_tabs
+                .reduce((prev: string | undefined | null, t: Tab) => {
+                    if (t.hidden || prev === null) return prev;
+                    const cc = containers.container(t.cookieStoreId)?.color;
+                    if (! cc) return prev;
+                    return prev === undefined || cc === prev ? cc : null;
+                }, undefined);
+            return container_color ?? undefined;
         },
 
         hasOpenTab(): boolean {

--- a/src/stash-list/bookmark.vue
+++ b/src/stash-list/bookmark.vue
@@ -67,7 +67,7 @@ export default defineComponent({
         },
 
         discarded(): boolean {
-            return this.related_tabs.length > 0 && 
+            return this.related_tabs.length > 0 &&
                 this.related_tabs.every(t => !t.hidden && t.discarded);
         },
 
@@ -84,7 +84,8 @@ export default defineComponent({
             //     set to the same color.
             const container_color = this.related_tabs
                 .reduce((prev: string | undefined | null, t: Tab) => {
-                    if (t.hidden || prev === null) return prev;
+                    if (t.hidden || prev === null || t.cookieStoreId === undefined)
+                        return prev;
                     const cc = containers.container(t.cookieStoreId)?.color;
                     if (! cc) return prev;
                     return prev === undefined || cc === prev ? cc : null;

--- a/src/stash-list/tab.vue
+++ b/src/stash-list/tab.vue
@@ -69,8 +69,10 @@ export default defineComponent({
             return this.tab.active && this.tab.windowId === this.targetWindow;
         },
         container(): Container | undefined {
-            if (!this.model().options.local.state.ff_container_indicators) return;
-            return this.model().containers.container(this.tab.cookieStoreId);
+            if (this.model().options.local.state.ff_container_indicators &&
+                this.tab.cookieStoreId !== undefined) {
+                    return this.model().containers.container(this.tab.cookieStoreId);
+                }
         },
         containerColor(): string | undefined {
             return this.container?.color;

--- a/src/stash-list/tab.vue
+++ b/src/stash-list/tab.vue
@@ -6,6 +6,7 @@
               'discarded': tab.discarded,
               'selected': tab.$selected}"
      :title="tab.title" :data-id="tab.id"
+     :data-container-color="containerColor"
      @click.prevent.stop="select">
   <item-icon class="action select"
              :src="favIcon"
@@ -30,6 +31,7 @@ import browser from 'webextension-polyfill';
 import {altKeyName, bgKeyName, required} from '../util';
 import {Model, copyIf} from '../model';
 import {Tab} from '../model/tabs';
+import {Container} from '../model/containers';
 
 export default defineComponent({
     components: {
@@ -65,6 +67,13 @@ export default defineComponent({
         },
         isActive(): boolean {
             return this.tab.active && this.tab.windowId === this.targetWindow;
+        },
+        container(): Container | undefined {
+            if (!this.model().options.local.state.ff_container_indicators) return;
+            return this.model().containers.container(this.tab.cookieStoreId);
+        },
+        containerColor(): string | undefined {
+            return this.container?.color;
         },
     },
 

--- a/src/ui-model.ts
+++ b/src/ui-model.ts
@@ -13,6 +13,7 @@ export default async function(): Promise<M.Model> {
         browser_settings: M.BrowserSettings.Model.live(),
         options: M.Options.Model.live(),
         tabs: M.Tabs.Model.from_browser(), // TODO load from cache
+        containers: M.Containers.Model.from_browser(),
         bookmarks: M.Bookmarks.Model.from_browser(), // TODO load from cache
         deleted_items: new M.DeletedItems.Model(
             new KVSClient<string, M.DeletedItems.SourceValue>('deleted_items')),

--- a/styles/folders.less
+++ b/styles/folders.less
@@ -126,7 +126,48 @@
     &.disabled { color: var(--disabled-fg); }
 }
 
+[data-container-color="blue"] {
+    --container-indicator-color: var(--container-color-blue);
+}
+
+[data-container-color="turquoise"] {
+    --container-indicator-color: var(--container-color-teal);
+}
+
+[data-container-color="green"] {
+    --container-indicator-color: var(--container-color-green);
+}
+
+[data-container-color="yellow"] {
+    --container-indicator-color: var(--container-color-yellow);
+}
+
+[data-container-color="orange"] {
+    --container-indicator-color: var(--container-color-orange);
+}
+
+[data-container-color="red"] {
+    --container-indicator-color: var(--container-color-red);
+}
+
+[data-container-color="pink"] {
+    --container-indicator-color: var(--container-color-magenta);
+}
+
+[data-container-color="purple"] {
+    --container-indicator-color: var(--container-color-purple);
+}
+
+[data-container-color="toolbar"] {
+    --container-indicator-color: var(--container-color-toolbar);
+}
+
+
 // Tab entries and other folder contents (e.g. count of hidden tabs)
+.folder-item[data-container-color] {
+    box-shadow: var(--container-indicator-shadow-style) var(--container-indicator-color);
+}
+
 .folder-item {
     display: grid;
     grid-template-columns: 0fr 0fr 1fr 0fr; // indentation, icon, title, actions

--- a/styles/theme-dark.less
+++ b/styles/theme-dark.less
@@ -57,6 +57,18 @@ there first. */
 
     // "Advanced" options background
     --advanced-bg: rgba(127, 81, 81, 0.5);
+
+    // Container colors and styles
+    --container-color-blue: blue;
+    --container-color-teal: teal;
+    --container-color-green: green;
+    --container-color-yellow: yellow;
+    --container-color-orange: orange;
+    --container-color-red: red;
+    --container-color-magenta: magenta;
+    --container-color-purple: purple;
+    --container-color-toolbar: #606060;
+    --container-indicator-shadow-style: inset -2px 0px 0px 0px;
 }
 
 &.view-tab {

--- a/styles/theme-light.less
+++ b/styles/theme-light.less
@@ -54,6 +54,18 @@
 
     // "Advanced" options background
     --advanced-bg: rgba(255, 224, 224, 0.5);
+
+    // Container colors and styles
+    --container-color-blue: rgb(52, 52, 252);
+    --container-color-teal: teal;
+    --container-color-green: green;
+    --container-color-yellow: yellow;
+    --container-color-orange: orange;
+    --container-color-red: red;
+    --container-color-magenta: magenta;
+    --container-color-purple: purple;
+    --container-color-toolbar: #909090;
+    --container-indicator-shadow-style: inset -3px 0px 0px 0px;
 }
 
 &.popup-view {


### PR DESCRIPTION
~~This is pretty rough since I don't actually know JavaScript, TypeScript _or_ Vue so it's pretty much cargo cult development. However, it does seem to work.~~ *edit*: Getting pretty reasonable now!

~~I'm submitting this draft to get some feedback of whether I'm even close to the right track.~~

### Changes

1. Adds a color coded indicator on the right side of tabs with the container color.
2. For bookmarks with tabs open that have containers, it will show a similar indicator but only if all the related tabs have the same container. Otherwise it just doesn't show a container indicator.
3. Adds a model that listens for contextual identity-related events and maintains state.

### Known Problems

- [x] ~~The internal naming is inconsistent. Should decide on calling them `contextualIdentities`, `identities`, `containers` or whatever.~~
- [x] ~~The CSS changes are likely not in the correct place, but I'm not really sure where they should be added.~~ (mostly done)
- [x] ~~There's some attempt to handle a case where there's no container support but probably not enough to make this work on a browser like Chrome.~~
- [x] ~~Does not repaint container indicators when container settings like color are changed.~~
- [x] ~~Minor: A case where container support in the browser is manually toggled likely wouldn't be handled correctly. Right now it just gives up dealing with containers if adding the listeners in the model constructor fails.~~ Mostly done, however re-enabling containers requires reloading Tab Stash before it will use them again.

### Possible Improvements

1. Define colors based on the theme to be as visible as possible.
2. The bookmark container behavior could be simplified if we just want to show an indicator for the first tab found with a container.

Associated issue: #125 