### PR TITLE
feat: Tab stats tooltips and indicate when folders have open tabs.

### DIFF
--- a/src/components/editable-label.vue
+++ b/src/components/editable-label.vue
@@ -4,7 +4,9 @@
        @mousedown.stop="; /* prevent parent from starting a drag */"
        @blur="commit" @keyup.enter.prevent="commit"
        @keyup.esc.prevent="cancel">
-<span v-else :title="displayValue" @click.prevent.stop="begin">{{displayValue}}</span>
+<span v-else :title="tooltipOrDisplayValue" @click.prevent.stop="begin">
+    {{displayValue}}
+</span>
 </template>
 
 <script lang="ts">
@@ -20,6 +22,7 @@ export default defineComponent({
 
         /** The value to show */
         value: String,
+        tooltip: String,
 
         /** The value to show if no value is provided */
         defaultValue: required(String),
@@ -36,6 +39,9 @@ export default defineComponent({
         },
         editableValue(): string {
             return this.dirtyValue ?? this.value ?? '';
+        },
+        tooltipOrDisplayValue(): string {
+            return this.tooltip ?? this.displayValue;
         },
     },
 

--- a/src/stash-list/bookmark.vue
+++ b/src/stash-list/bookmark.vue
@@ -61,8 +61,8 @@ export default defineComponent({
         },
 
         discarded(): boolean {
-            return this.related_tabs.length > 0 &&
-                this.related_tabs.every(t => !t.hidden && t.discarded);
+            return this.relatedTabs.length > 0 &&
+                this.relatedTabs.every(t => !t.hidden && t.discarded);
         },
 
         related_container_color(): string | undefined {
@@ -89,14 +89,11 @@ export default defineComponent({
         related_tabs(): readonly Tab[] { return this.relatedTabs; },
 
         hasOpenTab(): boolean {
-            return !! this.relatedTabs.find(
-                t => ! t.hidden && t.windowId === this.targetWindow);
+            return !! this.relatedTabs.find(t => ! t.hidden);
         },
 
         hasActiveTab(): boolean {
-            // TODO look only at the current window
-            return !! this.relatedTabs.find(
-                t => t.active && t.windowId === this.targetWindow);
+            return !! this.relatedTabs.find(t => t.active);
         },
 
         favicon(): FaviconEntry | null {
@@ -133,8 +130,8 @@ export default defineComponent({
 
         closeOrHideOrOpen(ev: MouseEvent) { this.model().attempt(async () => {
             const openTabs = this.relatedTabs
-                .filter((t) => ! t.hidden && t.windowId === this.targetWindow)
-                .map((t) => t.id);
+                .filter(t => ! t.hidden)
+                .map(t => t.id);
 
             // Remove keyboard focus after a middle click, otherwise focus will
             // remain within the element and it will appear to be highlighted.

--- a/src/stash-list/bookmark.vue
+++ b/src/stash-list/bookmark.vue
@@ -49,6 +49,7 @@ export default defineComponent({
 
     props: {
         bookmark: required(Object as PropType<Bookmark>),
+        relatedTabs: required(Object as PropType<Tab[]>),
     },
 
     computed: {
@@ -57,13 +58,6 @@ export default defineComponent({
 
         targetWindow(): number | undefined {
             return this.model().tabs.targetWindow.value;
-        },
-
-        related_tabs(): Tab[] {
-            if (! this.bookmark.url) return [];
-            const related = this.model().tabs.tabsWithURL(this.bookmark.url);
-            return Array.from(related)
-                .filter(t => t.windowId === this.targetWindow);
         },
 
         discarded(): boolean {
@@ -92,14 +86,17 @@ export default defineComponent({
                 }, undefined);
             return container_color ?? undefined;
         },
+        related_tabs(): readonly Tab[] { return this.relatedTabs; },
 
         hasOpenTab(): boolean {
-            return !! this.related_tabs.find(t => ! t.hidden);
+            return !! this.relatedTabs.find(
+                t => ! t.hidden && t.windowId === this.targetWindow);
         },
 
         hasActiveTab(): boolean {
             // TODO look only at the current window
-            return !! this.related_tabs.find(t => t.active);
+            return !! this.relatedTabs.find(
+                t => t.active && t.windowId === this.targetWindow);
         },
 
         favicon(): FaviconEntry | null {
@@ -135,7 +132,7 @@ export default defineComponent({
         })},
 
         closeOrHideOrOpen(ev: MouseEvent) { this.model().attempt(async () => {
-            const openTabs = this.related_tabs
+            const openTabs = this.relatedTabs
                 .filter((t) => ! t.hidden && t.windowId === this.targetWindow)
                 .map((t) => t.id);
 

--- a/src/stash-list/folder.vue
+++ b/src/stash-list/folder.vue
@@ -1,5 +1,7 @@
 <template>
-<section :class="{folder: true, 'action-container': true, collapsed: collapsed}"
+<section :class="{folder: true, 'action-container': true,
+         'has-open-tabs': openTabsCount > 0,
+         collapsed: collapsed}"
          :data-id="folder.id">
   <header>
     <Button :class="{collapse: ! collapsed, expand: collapsed}"
@@ -26,17 +28,19 @@
     <!-- This is at the end so it gets put in front of the buttons etc.
          Important to ensure the focused box-shadow gets drawn over the buttons,
          rather than behind them. -->
-    <editable-label :class="{'folder-name': true, 'ephemeral': true}"
-                    :value="nonDefaultTitle"
-                    :defaultValue="defaultTitle"
-                    :edit="rename"></editable-label>
+    <editable-label
+        class="folder-name ephemeral"
+        :value="nonDefaultTitle"
+        :defaultValue="defaultTitle"
+        :tooltip="tooltip"
+        :edit="rename"></editable-label>
   </header>
   <div class="contents">
-    <dnd-list class="tabs" v-model="children" item-key="id" :item-class="childClasses"
+    <dnd-list class="tabs" v-model="childrenWithTabs" item-key="id" :item-class="childClasses"
               :accepts="accepts" :drag="drag" :drop="drop" :mimic-height="true">
       <template #item="{item}">
-        <bookmark v-if="isValidChild(item)" :bookmark="item"
-                  :class="{'folder-item': true, 'no-match': ! item.$visible}" />
+        <bookmark v-if="isValidChild(item.node)" :bookmark="item.node" :relatedTabs="item.tabs"
+                  :class="{'folder-item': true, 'no-match': ! item.node.$visible}" />
       </template>
     </dnd-list>
     <div class="folder-item" v-if="filterCount > 0"
@@ -59,9 +63,12 @@ import {DragAction, DropAction} from '../components/dnd-list';
 
 import {copyIf, Model, StashItem} from '../model';
 import {
-    Node, Bookmark, Folder, genDefaultFolderName, getDefaultFolderNameISODate, friendlyFolderName,
+    Node, NodeID, Bookmark, Folder, genDefaultFolderName, getDefaultFolderNameISODate, friendlyFolderName,
 } from '../model/bookmarks';
 import {BookmarkMetadataEntry} from '../model/bookmark-metadata';
+import {Tab} from '../model/tabs';
+
+type NodeWithTabs = { node: Node, id: NodeID, tabs: Tab[]};
 
 const DROP_FORMATS = [
     'application/x-tab-stash-items',
@@ -95,6 +102,47 @@ export default defineComponent({
 
         accepts() { return DROP_FORMATS; },
 
+        targetWindow(): number | undefined {
+            return this.model().tabs.targetWindow.value;
+        },
+
+        childrenWithTabs(): readonly NodeWithTabs[] {
+            const mtabs = this.model().tabs;
+            return this.children
+                .map(n => {
+                    return {
+                        node: n, id: n.id,
+                        tabs: 'url' in n && n.url
+                            ? Array.from(mtabs.tabsWithURL(n.url))
+                                .filter(t => t.windowId === this.targetWindow)
+                            : []
+                    };
+                });
+        },
+
+        childTabStats(): { open: number, discarded: number, hidden: number } {
+            let open = 0, discarded = 0, hidden = 0;
+            for (const nwt of this.childrenWithTabs) {
+                for (const tab of nwt.tabs) {
+                    if (tab.windowId !== this.targetWindow) {
+                        continue;
+                    }
+                    if (tab.hidden) {
+                        hidden += 1;
+                    } else if (tab.discarded) {
+                        discarded += 1;
+                    } else {
+                        open += 1;
+                    }
+                }
+            }
+            return { open, discarded, hidden };
+        },
+
+        openTabsCount(): number {
+            return this.childTabStats.open + this.childTabStats.discarded;
+        },
+
         children(): readonly Node[] {
             return this.model().bookmarks.childrenOf(this.folder);
         },
@@ -127,6 +175,14 @@ export default defineComponent({
             return getDefaultFolderNameISODate(this.folder.title) !== null
                 ? undefined : this.folder.title;
         },
+        tooltip(): string {
+            const st = this.childTabStats;
+            const child_count = this.validChildren.length;
+            const statstip = `${child_count} stashed tab${
+                child_count != 1 ? 's' : ''}; ${st.open} open, ${
+                st.discarded} discarded, ${st.hidden} hidden`;
+            return `${this.nonDefaultTitle ?? this.defaultTitle}\n${statstip}`;
+        },
 
         validChildren(): Bookmark[] {
             return this.children.filter(c => this.isValidChild(c)) as Bookmark[];
@@ -148,7 +204,8 @@ export default defineComponent({
         model() { return (<any>this).$model as Model; },
         attempt(fn: () => Promise<void>) { this.model().attempt(fn); },
 
-        childClasses(node: Node): Record<string, boolean> {
+        childClasses(nodet: NodeWithTabs): Record<string, boolean> {
+            const node = nodet.node;
             return {hidden: ! (
                 this.isValidChild(node) && (this.showFiltered || node.$visible))};
         },

--- a/src/stash-list/index.vue
+++ b/src/stash-list/index.vue
@@ -48,6 +48,7 @@
     </Menu>
     <SelectionMenu v-if="selection_active" />
     <input type="search" ref="search" class="ephemeral" aria-label="Search"
+           :title="tooltip"
            :placeholder="search_placeholder" v-model="searchText">
     <Button :class="{collapse: ! collapsed, expand: collapsed}"
             title="Hide all tabs so only group names are showing"
@@ -163,6 +164,30 @@ export default defineComponent({
             return `Search ${counts.groups} ${groups}, ${counts.tabs} ${tabs}`;
         },
 
+        tabStats(): { open: number, discarded: number, hidden: number } {
+            let open = 0, discarded = 0, hidden = 0;
+            for (const tab of this.tabs) {
+                if (tab.hidden) {
+                    hidden += 1;
+                } else if (tab.discarded) {
+                    discarded += 1;
+                } else {
+                    open += 1;
+                }
+            }
+            return { open, discarded, hidden };
+        },
+
+        tooltip(): string {
+            const st = this.tabStats;
+            const tabs_sum = st.open + st.discarded + st.hidden;
+            return `${this.counts.groups} group${
+                this.plural(this.counts.groups)}, ${
+                this.counts.tabs} stashed tab${this.plural(this.counts.tabs)}\n${
+                tabs_sum} tab${this.plural(tabs_sum)} (${
+                st.open} open, ${st.discarded} unloaded, ${st.hidden} hidden)`;
+        },
+
         curWindowMetadata(): BookmarkMetadataEntry {
             return this.model().bookmark_metadata.get(CUR_WINDOW_MD_ID);
         },
@@ -251,6 +276,10 @@ export default defineComponent({
 
         showExportDialog() {
             this.dialog = {class: 'ExportDialog', props: {}};
+        },
+
+        plural(n: number): string {
+            return n == 1 ? '' : 's';
         },
 
         async fetchMissingFavicons() { this.model().attempt(async() => {

--- a/src/stash-list/window.vue
+++ b/src/stash-list/window.vue
@@ -33,6 +33,7 @@ ${altKey}+Click: Close any hidden/stashed tabs (reclaims memory)`" />
          Important to ensure the focused box-shadow gets drawn over the buttons,
          rather than behind them. -->
     <editable-label :class="{'folder-name': true, 'disabled': true}"
+                    :tooltip="tooltip"
                     :value="title" :defaultValue="title" />
   </header>
   <div class="contents">
@@ -102,6 +103,10 @@ export default defineComponent({
         title(): string {
             if (this.model().options.sync.state.show_all_open_tabs) return "Open Tabs";
             return "Unstashed Tabs";
+        },
+
+        tooltip(): string {
+            return `${this.validChildren.length} ${this.title}`;
         },
 
         collapsed: {

--- a/styles/folders.less
+++ b/styles/folders.less
@@ -164,7 +164,7 @@
 
 // This matches the text of an editable-label component that is not
 // currently being edited.
-&.has-open-tabs span.folder-name {
+&.has-open-tabs .folder-name {
     color: var(--userlink-fg);
     filter: saturate(0.7);
 }

--- a/styles/folders.less
+++ b/styles/folders.less
@@ -122,7 +122,6 @@
 
     // So that descenders and ascenders don't get clipped (much... :/)
     padding: var(--input-text-ph) var(--input-text-pw);
-
     &.disabled { color: var(--disabled-fg); }
 }
 
@@ -162,6 +161,13 @@
     --container-indicator-color: var(--container-color-toolbar);
 }
 
+
+// This matches the text of an editable-label component that is not
+// currently being edited.
+&.has-open-tabs span.folder-name {
+    color: var(--userlink-fg);
+    filter: saturate(0.7);
+}
 
 // Tab entries and other folder contents (e.g. count of hidden tabs)
 .folder-item[data-container-color] {


### PR DESCRIPTION
## Changes

1. Adds a tooltip showing open/unloaded/hidden tab stats to the search box.
2. Adds a tooltip showing the number of tabs in the "Open Tabs"/"Unstashed Tabs" group.
3. Adds a tooltip to stash folders showing the total number of items and number of open/unloaded/hidden tabs.
4. Displays folder titles that have open tabs in a similar style as bookmarks with open tabs. (Currently there was no way to know if a collapsed folder had open tabs.)

## To-do

Code cleanups. TBD if this seems like that's the only thing holding back acceptance of this PR. Status: semi-draft.

Associated issue: #185