### PR TITLE
build: Enable webpack build cache.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,10 @@ module.exports = {
     },
     mode: "production",
     devtool: "source-map",
+    cache: { 
+        type: 'filesystem', 
+        buildDependencies: { config: [__filename] },
+    },
     module: {
         rules: [
             {test: /\.vue$/, loader: 'vue-loader'},


### PR DESCRIPTION
This speeds up incremental builds a _lot_. Is there a reason not to use it?