### PR TITLE
fix: Bookmark open handler crashes due to renamed ref.

### DIFF
--- a/src/stash-list/bookmark.vue
+++ b/src/stash-list/bookmark.vue
@@ -89,7 +89,7 @@ export default defineComponent({
         })},
 
         open(ev: MouseEvent) { this.model().attempt(async () => {
-            (<HTMLElement>this.$refs.a).blur();
+            (<HTMLElement>this.$refs.link).blur();
             if (this.model().selection.selectedCount.value > 0) {
                 this.select(ev);
                 return;


### PR DESCRIPTION
The ref for bookmark links was renamed from `a` to `link` but the open handler still referred to `this.$refs.a`.