### PR TITLE
feat: Use bookmark favicon store for tabs with no favicon.

### DIFF
--- a/src/datastore/kvs/index.ts
+++ b/src/datastore/kvs/index.ts
@@ -105,6 +105,12 @@ export interface KeyValueStore<K extends Key, V extends Value> {
         return e;
     }
 
+    /** Returns an entry from the KVS, but only if it already
+     * exists in the store. */
+    getIfExists(key: K): Entry<K, V | null> | undefined {
+        return this._entries.get(key);
+    }
+
     /** Updates an entry in the KVS.  The cache is updated immediately, but
      * entries will be flushed in the background. */
     set(key: K, value: V): Entry<K, V | null> {

--- a/src/model/favicons.ts
+++ b/src/model/favicons.ts
@@ -61,6 +61,12 @@ export class Model {
      */
     get(url: string): FaviconEntry { return this._kvc.get(urlToOpen(url)); }
 
+    /** Retrieves a favicon from the catch, but won't trigger loading
+     * if the icon is not already present in the store. */
+    getIfExists(url: string): FaviconEntry | undefined {
+        return this._kvc.getIfExists(urlToOpen(url));
+    }
+
     /** Update the icon for a URL in the cache. */
     set(url: string, favIconUrl: string): FaviconEntry {
         return this._kvc.set(url, {favIconUrl});

--- a/src/stash-list/tab.vue
+++ b/src/stash-list/tab.vue
@@ -8,7 +8,7 @@
      :title="tab.title" :data-id="tab.id"
      @click.prevent.stop="select">
   <item-icon class="action select"
-             :src="! tab.$selected ? tab.favIconUrl : ''"
+             :src="favIcon"
              :default-class="{'icon-tab': ! tab.$selected,
                               'icon-tab-selected-inverse': tab.$selected}"
              @click.prevent.stop="select" />
@@ -49,6 +49,15 @@ export default defineComponent({
         bgKey: bgKeyName,
         targetWindow(): number | undefined {
             return this.model().tabs.targetWindow.value;
+        },
+        favIcon(): string {
+            if (this.tab.$selected) {
+                return '';
+            } else if (this.tab.favIconUrl) {
+                return this.tab.favIconUrl;
+            }
+            return this.model().favicons
+                .getIfExists(this.tab.url)?.value?.favIconUrl ?? '';
         },
         isActive(): boolean {
             return this.tab.active && this.tab.windowId === this.targetWindow;


### PR DESCRIPTION
Right now loading tabs will show the default tab icon until the actual page favicon is loaded, even though they were loaded from the stash and we almost certainly have a favicon available. Applying #225 to the default tab icon also looks pretty weird.

This pull just checks the store and uses a favicon (if found) until the tab has loaded its own favicon, which allows the correct favicon to be displayed immediately in most cases.