### PR TITLE
Show unstashable tabs in list when Show All Open Tabs option is enabled.

### DIFF
--- a/src/stash-list/tab.vue
+++ b/src/stash-list/tab.vue
@@ -16,7 +16,7 @@
      @click.left.prevent.stop="open"
      @auxclick.middle.exact.prevent.stop="remove">{{tab.title}}</a>
   <ButtonBox>
-    <Button class="stash one" @action="stash"
+    <Button v-if="isStashable" class="stash one" @action="stash"
             :tooltip="`Stash this tab (hold ${altKey} to keep tab open)`" />
     <Button class="remove" @action="remove" tooltip="Close this tab" />
   </ButtonBox>
@@ -49,6 +49,10 @@ export default defineComponent({
         bgKey: bgKeyName,
         targetWindow(): number | undefined {
             return this.model().tabs.targetWindow.value;
+        },
+        isStashable(): boolean {
+            const t = this.tab;
+            return ! t.hidden && ! t.pinned && this.model().isURLStashable(t.url);
         },
         isActive(): boolean {
             return this.tab.active && this.tab.windowId === this.targetWindow;

--- a/src/stash-list/window.vue
+++ b/src/stash-list/window.vue
@@ -139,9 +139,9 @@ export default defineComponent({
 
         isValidChild(t: Tab): boolean {
             const model = this.model();
-            return ! t.hidden && ! t.pinned && model.isURLStashable(t.url)
-                && (model.options.sync.state.show_all_open_tabs
-                    || ! this.isItemStashed(t));
+            if (t.hidden || t.pinned) return false;
+            return model.options.sync.state.show_all_open_tabs ||
+                (model.isURLStashable(t.url) && ! this.isItemStashed(t));
         },
 
         isItemStashed(i: Tab): boolean {

--- a/src/stash-list/window.vue
+++ b/src/stash-list/window.vue
@@ -161,9 +161,14 @@ export default defineComponent({
 
         async stash(ev: MouseEvent | KeyboardEvent) {this.attempt(async() => {
             if (this.visibleChildren.length === 0) return;
-            await this.model().putItemsInFolder({
-                items: copyIf(ev.altKey, this.visibleChildren),
-                toFolderId: (await this.model().bookmarks.createStashFolder()).id,
+
+            const model = this.model();
+            const stashable_visible_children = this.visibleChildren
+                .filter(t => model.isURLStashable(t.url));
+
+            await model.putItemsInFolder({
+                items: copyIf(ev.altKey, stashable_visible_children),
+                toFolderId: (await model.bookmarks.createStashFolder()).id,
             });
         })},
 


### PR DESCRIPTION
This pull allows unstashable tabs to show up in the "Open Tabs" list. The action icon to stash an unstashable tab will be hidden while it's in an unstashable state. I'm not sure if more protection against stashing the tab than this is necessary, since you can already do stuff like right click the page background in a unstashable tab and choose to stash it so it seems like Tab Stash will let you stash "unstashable" tabs if you _really_ want to.

The main advantage of this pull is it makes a huge difference in how response Tab Stash feels when opening new tabs. Many sites can take a second or two to reach a "stashable" state and currently the Tab Stash interface just doesn't react until then.