### PR TITLE
feat: WIP support for user style overrides.

### DIFF
--- a/assets/stash-list.html
+++ b/assets/stash-list.html
@@ -10,6 +10,17 @@
     <link rel="stylesheet" type="text/css" href="tab-stash.css">
     <script type="text/javascript" src="lib.js"></script>
     <script type="text/javascript" src="stash-list.js"></script>
+    <meta
+        http-equiv="Content-Security-Policy"
+        content="
+            default-src 'none';
+            style-src 'self' 'unsafe-inline';
+            base-uri 'self';
+            img-src 'self' data:
+                chrome://global/skin/icons/
+                chrome://browser/skin/
+                chrome://branding/content/
+                chrome://mozapps/skin/ ;">
   </head>
 
   <body>

--- a/src/model/options.ts
+++ b/src/model/options.ts
@@ -106,6 +106,9 @@ export const LOCAL_DEF = {
     /** Disable crash reports for a certain amount of time. */
     hide_crash_reports_until: {default: undefined, is: maybeUndef(aNumber)},
 
+    /** Custom CSS to be injected into the stash-list page. */
+    user_style_override: {default: undefined, is: maybeUndef(aString)},
+
     // Feature flags
     ff_popup_view: {default: false, is: aBoolean},
 

--- a/src/options/index.vue
+++ b/src/options/index.vue
@@ -192,6 +192,20 @@
     </ul>
   </section>
 
+  <section class="advanced">
+  <p><em><b>WARNING! EXTREME DANGER!</b>
+    Oh no! Oh no! Oh no! Oh no! Don't do it!
+  </em></p>
+    <label>User CSS override (not synced)</label>
+    <ul><li>
+      <label for="user_style_override"
+                  title="Custom CSS overrides">
+        Note: Deselecting the text area will commit changes.<br/>
+        <textarea v-model.lazy="user_style_override" rows="10" cols="80"></textarea>
+      </label>
+    </li></ul>
+  </section>
+
   <hr v-if="meta_show_advanced">
 
   <section class="advanced">

--- a/src/stash-list/index.vue
+++ b/src/stash-list/index.vue
@@ -1,4 +1,5 @@
 <template>
+<component is="style" v-if="user_style_override" v-text="user_style_override"></component>
 <main :class="{'selection-active': selection_active}" tabindex="0"
       @click="deselectAll" @keydown.esc.prevent.stop="onEscape">
   <transition-group tag="aside" class="notification-overlay" appear name="notification">
@@ -110,6 +111,9 @@ export default defineComponent({
     }),
 
     computed: {
+        user_style_override() {
+            return this.model().options.local.state.user_style_override ?? '';
+        },
         stash_root_warning(): {text: string, help: () => void} | undefined {
             return this.model().bookmarks.stash_root_warning.value;
         },


### PR DESCRIPTION
Proof of concept for allowing user style overrides.

Adds more CSP policies to further restrict the stash-list page privileges. Unfortunately I don't see a way to get around `style-src 'unsafe-inline'` part. Ideally a nonce or something would be used instead, but the `stash-list.html` page is static. The other policies should prevent anything like loading/importing remote resources.

The preferences part is really rough, although it is usable. Obviously it would need actual warnings for the dangers rather than those placeholders.

These styles only affect the stash-list page, so it's not possible to do something like make the options page unusable. Even something like `html { display: none !important; }` removes all content from the stash-list but can easily be reverted from the options.