### PR TITLE
fix: Incorrect bound logic in KVS getStartingFrom/EndingAt can cause unlimited CPU use.

### DIFF
--- a/src/datastore/kvs/service.ts
+++ b/src/datastore/kvs/service.ts
@@ -61,7 +61,8 @@ export default class Service<K extends Proto.Key, V extends Proto.Value>
     async getStartingFrom(
         bound: K | undefined, limit: number
     ): Promise<Proto.Entry<K, V>[]> {
-        const b = bound ? IDBKeyRange.lowerBound(bound, true) : undefined;
+        const b = bound !== undefined ?
+            IDBKeyRange.lowerBound(bound, true) : undefined;
 
         const txn = this._db.transaction(this.name);
         let cursor = await txn.store.openCursor(b);
@@ -82,7 +83,8 @@ export default class Service<K extends Proto.Key, V extends Proto.Value>
     async getEndingAt(
         bound: K | undefined, limit: number
     ): Promise<Proto.Entry<K, V>[]> {
-        const b = bound ? IDBKeyRange.upperBound(bound, true) : undefined;
+        const b = bound !== undefined ?
+            IDBKeyRange.upperBound(bound, true) : undefined;
 
         const txn = this._db.transaction(this.name);
         let cursor = await txn.store.openCursor(b, 'prev');


### PR DESCRIPTION
A blank string key in a KVS item could cause `genericList` to spin endlessly due to the chunk getter functions incorrectly using Javascript truthiness on the bound instead of comparing specifically to `undefined`.

Bookmark metadata is stored using the KVS and the key for the `Open Tabs`/`Unstashed Tabs` item is an empty string.

Closes #240