### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,23 +11,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install inkscape
-      run: sudo apt-get install -y inkscape
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: 16.x
-    - name: Build
-      run: |
-        make debug
-    - name: Firefox artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: firefox
-        path: dist/**/*
-    - name: Chrome artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: chrome
-        path: dist-chrome/**/*
+      - name: Install Inkscape
+        run: sudo apt-get install -y inkscape
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: Install Node Modules
+        run: make node_modules
+      - name: Check Types
+        run: make check-types
+      - name: Check Style
+        run: make check-style
+      - name: Build
+        run: make build-dbg build-chrome-dbg
+      - name: Test
+        run: make check-tests
+      - name: Make Firefox Package (Debug)
+        uses: actions/upload-artifact@v3
+        with:
+          name: firefox
+          path: dist/**/*
+      - name: Make Chrome Package (Debug)
+        uses: actions/upload-artifact@v3
+        with:
+          name: chrome
+          path: dist-chrome/**/*


### PR DESCRIPTION
- Atomize the steps for nicer output in the GitHub Actions UI
- Fix code style to keep Prettier happy
- Use Node 18.x (latest LTS release)