### PR TITLE
Add Codecov to GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
         run: make build-dbg build-chrome-dbg
       - name: Test
         run: make check-tests
+      - name: Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage/lcov.info
       - name: Make Firefox Package (Debug)
         uses: actions/upload-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Tab Stash
 
 [![ci](https://github.com/josh-berry/tab-stash/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/josh-berry/tab-stash/actions?query=branch%3Amaster+)
+[![codecov](https://codecov.io/gh/josh-berry/tab-stash/branch/master/graph/badge.svg)](https://codecov.io/gh/josh-berry/tab-stash)
 
 Can't keep all your tabs straight? Need to clear your plate, but want to come
 back to your tabs later?


### PR DESCRIPTION
please add https://docs.codecov.com/docs/team-bot to Org

or alternatively I can submit PR with codecov.yml https://docs.codecov.com/docs/codecovyml-reference

might have to be merged (so primary branch baseline is uploaded) before fully functional (or might require followup tweaks)

https://app.codecov.io/gh/gliptak/tab-stash/pull/3