### PR TITLE
ci: Use install-deps.sh to install system dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install Inkscape
-        run: sudo apt-get update -y && sudo apt-get install -y inkscape
       - uses: actions/checkout@v1
+      - name: Install Dependencies
+        run: sh ./install-deps.sh
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -10,6 +10,9 @@ deps_apt() {
         fi
     fi
 
+    # Make sure we have the latest packages
+    sudo apt-get update
+
     # Inkscape
     if type snap; then
         if snap list inkscape 2>/dev/null; then
@@ -25,7 +28,7 @@ deps_apt() {
             sudo add-apt-repository universe
             sudo apt-get update
         fi
-        sudo apt install -y inkscape
+        sudo apt-get install -y inkscape
     fi
 
     # Build tools


### PR DESCRIPTION
This is the official way to install dependencies that is provided to Mozilla during the add-on review process; we should make sure it works properly in CI.