### PR TITLE
Fix chromium options page and duplicate stash timeout

### DIFF
--- a/chrome-manifest.patch
+++ b/chrome-manifest.patch
@@ -27,7 +27,7 @@
      },
      "theme_icons": [
        {
-@@ -60,43 +57,6 @@
+@@ -60,44 +57,8 @@
      ],
      "browser_style": false
    },
@@ -70,8 +70,11 @@
 -  },
    "options_ui": {
      "page": "options.html",
-     "browser_style": true
-@@ -104,21 +64,9 @@
+-    "browser_style": true
++    "browser_style": true,
++    "open_in_tab": true
+   },
+@@ -104,21 +65,9 @@
    "commands": {
      "_execute_browser_action": {
        "suggested_key": {

--- a/src/model/bookmarks.ts
+++ b/src/model/bookmarks.ts
@@ -510,6 +510,15 @@ export class Model {
     // situation, soooo... *shrug*)
     toIndex = Math.min(toParent.children.length, Math.max(0, toIndex));
 
+    // Detect same-folder no-op moves before calling the browser API. When an
+    // item moves forward in its current folder, removing it from its old
+    // position will shift the final index back by one.
+    let finalIndex = toIndex;
+    if (position.parent === toParent && toIndex > position.index) {
+      finalIndex = toIndex - 1;
+    }
+    if (position.parent === toParent && finalIndex === position.index) return;
+
     /* c8 ignore next -- platform-specific check */
     if (!!browser.runtime.getBrowserInfo) {
       // We're using Firefox

--- a/src/model/bookmarks.ts
+++ b/src/model/bookmarks.ts
@@ -510,22 +510,23 @@ export class Model {
     // situation, soooo... *shrug*)
     toIndex = Math.min(toParent.children.length, Math.max(0, toIndex));
 
-    // Detect same-folder no-op moves before calling the browser API. When an
-    // item moves forward in its current folder, removing it from its old
-    // position will shift the final index back by one.
-    let finalIndex = toIndex;
-    if (position.parent === toParent && toIndex > position.index) {
-      finalIndex = toIndex - 1;
-    }
-    if (position.parent === toParent && finalIndex === position.index) return;
-
     /* c8 ignore next -- platform-specific check */
     if (!!browser.runtime.getBrowserInfo) {
       // We're using Firefox
       if (position.parent === toParent) {
         if (toIndex > position.index) toIndex--;
       }
+    } else {
+      // Detect Chromium no-op moves before calling the browser API. When an
+      // item moves forward in its current folder, removing it from its old
+      // position will shift the final index back by one.
+      let finalIndex = toIndex;
+      if (position.parent === toParent && toIndex > position.index) {
+        finalIndex = toIndex - 1;
+      }
+      if (position.parent === toParent && finalIndex === position.index) return;
     }
+
     const oldParent = node.position?.parent;
     const oldIndex = node.position?.index;
     await browser.bookmarks.move(node.id, {

--- a/src/model/bookmarks.ts
+++ b/src/model/bookmarks.ts
@@ -517,9 +517,12 @@ export class Model {
         if (toIndex > position.index) toIndex--;
       }
     } else {
-      // Detect Chromium no-op moves before calling the browser API. When an
-      // item moves forward in its current folder, removing it from its old
-      // position will shift the final index back by one.
+      // We're using Chromium. Same-folder forward moves can be no-ops when the
+      // bookmark is already at the effective destination. For example, moving
+      // the last child to `children.length` leaves it at `children.length - 1`.
+      // In that case, the model position stays at `oldIndex`, while the poll
+      // below would wait for `toIndex` and eventually time out. Skip the move
+      // entirely when we can tell it would not change the effective position.
       let finalIndex = toIndex;
       if (position.parent === toParent && toIndex > position.index) {
         finalIndex = toIndex - 1;


### PR DESCRIPTION
Hi,

In this PR, I have fixed two chromium specific bugs:
1. Add `open_in_tab: true` to the manifest patch for chromium so that the options page will be shown in a normal tab. This was necessary since chromium does not have the setting page like firefox's add-ons manager.
2. Avoid chromium bookmark move timeouts when stashing a page that is already stashed. Chromium can treat same-folder bookmark moves as no-ops. Thus, I observed that when stashing a page that is already stashed in the target folder, a time out error will be seen.

I have checked the code by running `make check` and `make fix-style`.

Thanks in advance for your review!