### PR TITLE
Add Chrome Manifest V3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Tab Stash
 
+## Chrome development build
+
+This fork includes an experimental Manifest V3 port for Chromium browsers.
+
+1. Install Node.js 20 or newer.
+2. Run `npm ci`.
+3. Run `npm run build:chrome`.
+4. Open `chrome://extensions`, enable **Developer mode**, choose
+   **Load unpacked**, and select `dist-chrome`.
+
+The Chrome port uses Chrome's side panel in place of Firefox's sidebar. Saved
+groups remain real bookmark folders. Firefox-only hidden tabs and container
+metadata are unavailable.
+
 [![ci](https://github.com/josh-berry/tab-stash/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/josh-berry/tab-stash/actions?query=branch%3Amaster+)
 [![codecov](https://codecov.io/gh/josh-berry/tab-stash/branch/master/graph/badge.svg)](https://codecov.io/gh/josh-berry/tab-stash)
 

--- a/assets/manifest-chrome.json
+++ b/assets/manifest-chrome.json
@@ -1,0 +1,39 @@
+{
+  "manifest_version": 3,
+  "name": "Tab Stash for Chrome",
+  "version": "0.1.0",
+  "description": "Save and restore groups of tabs as bookmark-backed folders.",
+  "homepage_url": "https://github.com/josh-berry/tab-stash/",
+  "minimum_chrome_version": "114",
+  "permissions": [
+    "sessions",
+    "tabs",
+    "bookmarks",
+    "contextMenus",
+    "storage",
+    "unlimitedStorage",
+    "sidePanel"
+  ],
+  "background": {
+    "service_worker": "index.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Tab Stash"
+  },
+  "side_panel": {
+    "default_path": "stash-list.html?view=sidebar"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+T",
+        "mac": "MacCtrl+Shift+T"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -35,5 +35,7 @@
     "web-ext": "^8.2",
     "webextension-polyfill": "^0.10"
   },
-  "scripts": {}
+  "scripts": {
+    "build:chrome": "node scripts/build-chrome.mjs"
+  }
 }

--- a/scripts/build-chrome.mjs
+++ b/scripts/build-chrome.mjs
@@ -1,0 +1,81 @@
+import {spawnSync} from "node:child_process";
+import {
+  copyFileSync,
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import {resolve} from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const dist = resolve(root, "dist");
+const chrome_dist = resolve(root, "dist-chrome");
+const source_icons = resolve(root, "icons");
+
+const tools = {
+  less: resolve(root, "node_modules", "less", "bin", "lessc"),
+  vite: resolve(root, "node_modules", "vite", "bin", "vite.js"),
+};
+
+function run_node(script, args, env = {}) {
+  const result = spawnSync(process.execPath, [script, ...args], {
+    cwd: root,
+    env: {...process.env, ...env},
+    stdio: "inherit",
+  });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+rmSync(dist, {recursive: true, force: true});
+rmSync(chrome_dist, {recursive: true, force: true});
+mkdirSync(dist, {recursive: true});
+
+run_node(tools.less, [
+  "--math=strict",
+  "styles/index.less",
+  "dist/tab-stash.css",
+]);
+run_node(
+  tools.vite,
+  ["build", "-c", "vite.config.html.ts", "-m", "production"],
+  {NODE_ENV: "production"},
+);
+run_node(
+  tools.vite,
+  ["build", "-c", "vite.config.lib.ts", "-m", "production"],
+  {
+    NODE_ENV: "production",
+  },
+);
+
+cpSync(resolve(root, "assets"), dist, {recursive: true});
+mkdirSync(resolve(dist, "icons"), {recursive: true});
+cpSync(source_icons, resolve(dist, "icons"), {recursive: true});
+
+for (const [theme, color] of [
+  ["light", "#222426"],
+  ["dark", "#fbfbfe"],
+]) {
+  const target = resolve(dist, "icons", theme);
+  mkdirSync(target, {recursive: true});
+  for (const name of readdirSync(source_icons)) {
+    if (!name.endsWith(".svg")) continue;
+    const source = readFileSync(resolve(source_icons, name), "utf8");
+    writeFileSync(
+      resolve(target, name),
+      source.replace(/style="[^"]*"/g, `style="fill:${color}"`),
+    );
+  }
+}
+
+copyFileSync(
+  resolve(root, "assets", "manifest-chrome.json"),
+  resolve(dist, "manifest.json"),
+);
+rmSync(resolve(dist, "manifest-chrome.json"));
+cpSync(dist, chrome_dist, {recursive: true});
+
+console.log(`Chrome extension built at ${chrome_dist}`);

--- a/src/datastore/kvs/service.ts
+++ b/src/datastore/kvs/service.ts
@@ -21,8 +21,13 @@ export default class Service<K extends Proto.Key, V extends Proto.Value>
   ): Promise<Service<K, V>> {
     // Magical incantation to make sure the browser doesn't spontaneously
     // delete our store.
-    if (!(await navigator.storage.persisted())) {
-      await navigator.storage.persist();
+    const storage = navigator.storage;
+    if (
+      typeof storage?.persisted === "function" &&
+      typeof storage?.persist === "function" &&
+      !(await storage.persisted())
+    ) {
+      await storage.persist();
     }
 
     return new Service(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 /* c8 ignore start -- main entry point for the background page */
 
-import type {Menus} from "webextension-polyfill";
+import type {Menus, Tabs as BrowserTabs} from "webextension-polyfill";
 import browser from "webextension-polyfill";
 
 import {copyIf} from "./model/index.js";
@@ -15,6 +15,9 @@ import {
   urlToOpen,
 } from "./util/index.js";
 import {logErrorsFrom} from "./util/oops.js";
+
+const toolbar_action = (<any>browser).action ?? browser.browserAction;
+const chrome_side_panel = (<any>browser).sidePanel;
 
 logErrorsFrom(async () => {
   // BEGIN FILE-WIDE ASYNC BLOCK
@@ -63,6 +66,8 @@ logErrorsFrom(async () => {
   // correspond to field names in the commands object.
   //
 
+  if (chrome_side_panel) await browser.contextMenus.removeAll();
+
   function menu(
     idprefix: string,
     contexts: Menus.ContextType[],
@@ -84,13 +89,22 @@ logErrorsFrom(async () => {
           "selection",
         ],
     );
-    contexts = contexts.filter(x => allowed_ctxs.includes(x));
+    contexts = contexts
+      .map(x =>
+        chrome_side_panel && (x === "browser_action" || x === "page_action")
+          ? <any>"action"
+          : x,
+      )
+      .filter((x, i, all) => allowed_ctxs.includes(x) && all.indexOf(x) === i);
+    if (contexts.length === 0) return;
 
+    let separator = 0;
     for (let [id, title] of def) {
       if (id) {
         browser.contextMenus.create({contexts, title, id: idprefix + id});
       } else {
         browser.contextMenus.create({
+          id: `${idprefix}separator-${separator++}`,
           contexts,
           type: "separator",
           enabled: false,
@@ -99,16 +113,17 @@ logErrorsFrom(async () => {
     }
   }
 
-  const SHOW_TAB_NAME = browser.sidebarAction
-    ? "Show Stashed Tabs in a Tab"
-    : "Show Stashed Tabs";
+  const SHOW_TAB_NAME =
+    browser.sidebarAction || chrome_side_panel
+      ? "Show Stashed Tabs in a Tab"
+      : "Show Stashed Tabs";
 
   menu(
     "1:",
     ["tab", "page", "tools_menu"],
     [
       ["show_tab", SHOW_TAB_NAME],
-      ...(browser.sidebarAction
+      ...(browser.sidebarAction || chrome_side_panel
         ? [["show_sidebar_or_tab", "Show Stashed Tabs in Sidebar"]]
         : []),
       ["", ""],
@@ -129,7 +144,7 @@ logErrorsFrom(async () => {
     ["browser_action"],
     [
       ["show_tab", SHOW_TAB_NAME],
-      ...(browser.sidebarAction
+      ...(browser.sidebarAction || chrome_side_panel
         ? [["show_sidebar_or_tab", "Show Stashed Tabs in Sidebar"]]
         : []),
       ["", ""],
@@ -143,7 +158,7 @@ logErrorsFrom(async () => {
     ["page_action"],
     [
       ["show_tab", SHOW_TAB_NAME],
-      ...(browser.sidebarAction
+      ...(browser.sidebarAction || chrome_side_panel
         ? [["show_sidebar_or_tab", "Show Stashed Tabs in Sidebar"]]
         : []),
       ["", ""],
@@ -161,10 +176,17 @@ logErrorsFrom(async () => {
     // Also note that some browsers don't support the sidebar at all; in these
     // cases, we open the tab instead.
 
-    show_sidebar_or_tab: () =>
-      browser.sidebarAction
-        ? browser.sidebarAction.open().catch(console.log)
-        : commands.show_tab(),
+    show_sidebar_or_tab: async tab => {
+      if (browser.sidebarAction) {
+        await browser.sidebarAction.open().catch(console.log);
+      } else if (chrome_side_panel && tab?.position?.parent?.id !== undefined) {
+        await chrome_side_panel
+          .open({windowId: tab.position.parent.id})
+          .catch(console.log);
+      } else {
+        await commands.show_tab(tab);
+      }
+    },
 
     async show_popup() {
       // Ugh, this hack where we set and then clear the popup is necessary
@@ -173,25 +195,35 @@ logErrorsFrom(async () => {
       // rather than running the browserAction.onClicked callback (which might
       // do other things besides setting the popup).
       try {
-        await browser.browserAction.setPopup({
+        await toolbar_action.setPopup({
           popup: "stash-list.html?view=popup",
         });
-        await browser.browserAction.openPopup();
+        await toolbar_action.openPopup();
       } finally {
-        await browser.browserAction.setPopup({popup: ""});
+        await toolbar_action.setPopup({popup: ""});
       }
     },
 
-    async show_tab() {
-      await model.restoreTabs(
-        [
-          {
-            title: "Tab Stash",
-            url: browser.runtime.getURL("stash-list.html"),
-          },
-        ],
-        {},
-      );
+    async show_tab(tab?: Tab) {
+      if (chrome_side_panel) {
+        const window_id =
+          tab?.position?.parent?.id ??
+          (await browser.windows.getLastFocused()).id;
+        await browser.tabs.create({
+          windowId: window_id,
+          url: browser.runtime.getURL("stash-list.html"),
+        });
+      } else {
+        await model.restoreTabs(
+          [
+            {
+              title: "Tab Stash",
+              url: browser.runtime.getURL("stash-list.html"),
+            },
+          ],
+          {},
+        );
+      }
     },
 
     async stash_all(tab?: Tab) {
@@ -231,20 +263,20 @@ logErrorsFrom(async () => {
   // Shows the Tab Stash UI in the manner requested by /show_what/.  NOTE that to
   // be able to open the sidebar, this function must be invoked in a
   // user-initiated event handler context BEFORE any async operations are done.
-  function show_something(show_what?: ShowWhatOpt) {
+  function show_something(show_what?: ShowWhatOpt, tab?: Tab) {
     switch (show_what) {
       case "none":
         break;
 
       case "tab":
-        model.attempt(commands.show_tab);
+        model.attempt(() => commands.show_tab(tab));
         break;
 
       case "popup":
         model.attempt(commands.show_popup);
 
       case "sidebar":
-        model.attempt(commands.show_sidebar_or_tab);
+        model.attempt(() => commands.show_sidebar_or_tab(tab));
         break;
 
       default:
@@ -306,7 +338,7 @@ logErrorsFrom(async () => {
     commands[cmd](t).catch(console.log);
   });
 
-  if (browser.browserAction) {
+  if (toolbar_action) {
     // In order for show_something('popup') to work, we must preconfigure the
     // browser to know which popup to show.  This cannot be done at the time of
     // show_something() because doing so requires an async call, and Firefox
@@ -319,28 +351,28 @@ logErrorsFrom(async () => {
           // will no longer run (the popup will be shown instead).  This
           // unfortunately means that we can't stash and show the popup at
           // the same time.  Sigh.
-          await browser.browserAction.setPopup({
+          await toolbar_action.setPopup({
             popup: "stash-list.html?view=popup",
           });
         } else {
           // If the user turns off the popup, we must clear the popup in
           // the browser if we expect anything else to work.
-          await browser.browserAction.setPopup({popup: ""});
+          await toolbar_action.setPopup({popup: ""});
         }
       });
     }
     setupPopup();
     model.options.sync.onChanged.addListener(setupPopup);
 
-    browser.browserAction.onClicked.addListener(
-      asyncEvent(async tab => {
+    toolbar_action.onClicked.addListener(
+      asyncEvent(async (tab: BrowserTabs.Tab) => {
         const opts = model.options.sync.state;
         // Special case so the user doesn't think Tab Stash is broken
         if (!opts.browser_action_show || !opts.browser_action_stash) {
           show_setup_page();
           return;
         }
-        show_something(opts.browser_action_show);
+        show_something(opts.browser_action_show, model.tabs.tab(tab.id!)!);
         await stash_something({
           what: opts.browser_action_stash,
           tab: model.tabs.tab(tab.id!)!,
@@ -397,8 +429,8 @@ logErrorsFrom(async () => {
         }
       }
 
-      if (browser.browserAction) {
-        await browser.browserAction.setTitle({
+      if (toolbar_action) {
+        await toolbar_action.setTitle({
           title: getTitle(opts.state.browser_action_stash),
         });
       }

--- a/src/model/index.test.ts
+++ b/src/model/index.test.ts
@@ -224,6 +224,19 @@ describe("model", () => {
       );
     });
 
+    it("keeps local-file tabs stashable in Firefox", () => {
+      expect(env.model.isURLStashable("file:///tmp/example.txt")).to.be.true;
+    });
+
+    it("does not stash local-file tabs in Chromium", () => {
+      const get_browser_info = browser.runtime.getBrowserInfo;
+      (<any>browser.runtime).getBrowserInfo = undefined;
+      try {
+        expect(env.model.isURLStashable("file:///tmp/example.txt")).to.be.false;
+      } finally {
+        (<any>browser.runtime).getBrowserInfo = get_browser_info;
+      }
+    });
     it("chooses all non-hidden, non-pinned and non-privileged tabs", () => {
       const win = env.model.tabs.window(env.windows.real.id)!;
       expect(env.model.stashableTabsInWindow(win).map(t => t.id)).to.deep.equal(

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -283,9 +283,13 @@ export class Model {
     // New-tab URLs, homepages and the like are never stashable.
     if (this.browser_settings.isNewTabURL(url_str)) return false;
 
-    // Invalid URLs are not stashable.
+    // Invalid URLs are not stashable. Chromium also cannot reliably reopen
+    // local files without a separate per-extension permission toggle.
     try {
-      new URL(url_str);
+      const url = new URL(url_str);
+      if (!browser.runtime.getBrowserInfo && url.protocol === "file:") {
+        return false;
+      }
     } catch (e) {
       return false;
     }

--- a/src/model/options.ts
+++ b/src/model/options.ts
@@ -162,12 +162,23 @@ export class Model {
   readonly local: StoredObject<typeof LOCAL_DEF>;
 
   static async live(): Promise<Model> {
-    return new Model(
+    const model = new Model(
       await resolveNamed({
         sync: stored_object("sync", "options", SYNC_DEF),
         local: stored_object("local", "options", LOCAL_DEF),
       }),
     );
+
+    // Chromium has no tabs.hide() API. Migrate Firefox-only choices so the
+    // stored option matches what Chromium can actually do.
+    if (
+      !browser.tabs.hide &&
+      model.local.state.after_stashing_tab !== "close"
+    ) {
+      await model.local.set({after_stashing_tab: "close"});
+    }
+
+    return model;
   }
 
   constructor(src: Source) {
@@ -193,9 +204,14 @@ export class Model {
     );
   });
 
+  /** Can this browser keep stashed tabs alive while hiding them? */
+  canHideTabs(): boolean {
+    return typeof browser.tabs.hide === "function";
+  }
+
   /** Is the Firefox sidebar supported? */
   hasSidebar(): boolean {
-    return !!browser.sidebarAction;
+    return !!browser.sidebarAction || !!(<any>browser).sidePanel;
   }
 
   /** Based on the current settings, what can the toolbar stash? */
@@ -212,7 +228,7 @@ export class Model {
 
   /** Based on the current settings, what UIs can the browser show? */
   canBrowserActionShow(what: ShowWhatOpt): boolean {
-    if (what === "sidebar" && !browser.sidebarAction) return false;
+    if (what === "sidebar" && !this.hasSidebar()) return false;
 
     const browserActionStash = this.sync.state.browser_action_stash;
 

--- a/src/model/tabs.test.ts
+++ b/src/model/tabs.test.ts
@@ -44,6 +44,26 @@ describe("model/tabs", () => {
     }
   });
 
+  it("creates lazy tabs as discarded in Chromium", async () => {
+    (<any>browser.tabs).hide = undefined;
+    try {
+      const creating = model.create({
+        windowId: windows.left.id,
+        url: `${B}#lazy-chromium-tab`,
+        active: false,
+        discarded: true,
+      });
+
+      await events.next(browser.tabs.onCreated);
+      await events.nextN(browser.tabs.onUpdated, 2);
+
+      const tab = await creating;
+      expect(tab.url).to.equal(`${B}#lazy-chromium-tab`);
+      expect(tab.discarded).to.be.true;
+    } finally {
+      delete (<any>browser.tabs).hide;
+    }
+  });
   it("tracks tabs by window", async () => {
     for (const w in windows) {
       const win = windows[w as keyof typeof windows];

--- a/src/model/tabs.ts
+++ b/src/model/tabs.ts
@@ -266,10 +266,33 @@ export class Model {
   async create(tab: browser.Tabs.CreateCreatePropertiesType): Promise<Tab> {
     const create_tab = Object.assign({}, tab);
 
+    if (!browser.tabs.hide && tab.discarded && tab.url) {
+      // Chrome cannot create a tab in the discarded state. Create it inactive,
+      // then discard it immediately so page execution waits for selection.
+      delete create_tab.discarded;
+      delete create_tab.title;
+      create_tab.active = false;
+
+      trace("creating lazy Chrome tab", create_tab);
+      const created = await browser.tabs.create(create_tab);
+      const model_tab = await shortPoll(
+        () => this.tabs.get(created.id as TabID) || tryAgain(),
+      );
+      // tabs.create() can initially report about:blank while the requested URL
+      // is still pending. Discarding at that point loses the destination.
+      await shortPoll(
+        () => (model_tab.url && model_tab.url !== "about:blank") || tryAgain(),
+        1000,
+      );
+      await browser.tabs.discard(created.id!);
+      await shortPoll(() => model_tab.discarded || tryAgain());
+      return model_tab;
+    }
     if (!browser.tabs.hide || !tab.url || tab.url.startsWith("about:")) {
-      // This is Chrome; it doesn't support discarded tabs, so we can only load
-      // so many at once.  This is a little awkward because to the user, it will
-      // look like there is a big delay in opening tabs.
+      // Chrome cannot create already-discarded tabs. This rate-limited path
+      // handles immediate loading. Firefox about: pages also use it, so we can
+      // only load so many at once. This can look like a delay when opening
+      // several tabs.
       //
       // (It could also be Firefox, which doesn't support creating discarded
       // `about:` tabs.)
@@ -611,9 +634,13 @@ export class Model {
       // browser.tabs.query() still returns the closed tab.  We work around this
       // by simply ignoring onUpdated events for tabs we don't recognize.
       // https://github.com/josh-berry/tab-stash/issues/321
-      console.warn(
-        `Got onUpdated event for an unknown tab ${id}; ignoring it.`,
-      );
+      if (!browser.tabs.hide) {
+        trace("event tabUpdated ignored unknown tab", id, info);
+      } else {
+        console.warn(
+          `Got onUpdated event for an unknown tab ${id}; ignoring it.`,
+        );
+      }
       return;
     }
     /* c8 ignore stop */

--- a/src/options/index.vue
+++ b/src/options/index.vue
@@ -214,7 +214,7 @@
     <section>
       <label>Once a tab has been stashed:</label>
       <ul>
-        <li>
+        <li v-if="model.canHideTabs()">
           <label
             for="after_stashing_tab_hide"
             title="Hidden tabs that are still loaded can be restored instantly. They also preserve anything you had entered into the tab and its history (e.g. Back button)."
@@ -322,7 +322,7 @@
             </li>
           </ul>
         </li>
-        <li>
+        <li v-if="model.canHideTabs()">
           <label
             for="after_stashing_tab_hide_discard"
             title="Hidden tabs that are unloaded can be restored very quickly, and usually without a network connection. They also preserve browsing history (e.g. Back button). However, depending on the website, you may lose anything you had entered into the tab that isn't already saved. Uses less memory."


### PR DESCRIPTION
Couldn't find a good Tab Stash equivalent for Chromium. So I had AI port the Firefox extension. The contributing documentation didn't mention prohibiting AI contributions and this contribution is virtually entirely AI (except for the PR description). If this project isn't interested in that type of thing then I completely understand if you'd prefer not to merge.

I did make sure to manually go through and test the basic features of the extension and confirmed they work. 
I read through the code the AI generated and nothing seemed egregious or overly slopified. However, I don't write a lot of JavaScript and have certainly never written an extension/addon so I'm certainly no expert. 

Some notes:
- Had to exclude local `file:` tabs for Chrome because Chrome doesn't allow them to be restored reliably
- Hides Firefox-only settings (such as those featuring tab hiding) 
- Shouldn't impact the Firefox addon. Any meaningful changes made are branched to only affect Chrome
- All 576 existing tests pass (3 added for Chrome changes)
- Tested on Windows only

Resolves [issue#52](https://github.com/josh-berry/tab-stash/issues/52)

I'm happy to address minor review comments or fix issues with the implementation. If the project would prefer a substantially different approach or a major rewrite, I probably won't have time to take that on. The extension works well for my use case, so I wanted to contribute it in case it's useful for others or could be a good jumping-off point for a better implementation.